### PR TITLE
Implement namespacing (issue #2)

### DIFF
--- a/src/angularStorage/services/store.js.js
+++ b/src/angularStorage/services/store.js.js
@@ -7,18 +7,32 @@ angular.module('angular-storage.store', ['angular-storage.storage'])
     store.namespace = null;
     store.namespaceDelimiter = '.';
 
-    function getNamespacedKey(name) {
-      return store.namespace ? [store.namespace, name].join(store.namespaceDelimiter) : name;
+    function getNamespacedKey(name, namespace) {
+      var key;
+
+      if (namespace === null) {
+        key = name;
+      }
+      else {
+        if (namespace) {
+          key = [namespace, name].join(store.namespaceDelimiter);
+        }
+        else {
+          key = store.namespace ? [store.namespace, name].join(store.namespaceDelimiter) : name
+        }
+      }
+
+      return key;
     }
 
-    store.set = function(name, elem) {
-      var key = getNamespacedKey(name);
+    store.set = function(name, elem, namespace) {
+      var key = getNamespacedKey(name, namespace);
       store.inMemoryCache[key] = elem;
       storage.set(key, JSON.stringify(elem));
     };
 
-    store.get = function(name) {
-      var key = getNamespacedKey(name);
+    store.get = function(name, namespace) {
+      var key = getNamespacedKey(name, namespace);
       if (key in store.inMemoryCache) {
         return store.inMemoryCache[key];
       }
@@ -28,8 +42,8 @@ angular.module('angular-storage.store', ['angular-storage.storage'])
       return obj;
     };
 
-    store.remove = function(name) {
-      var key = getNamespacedKey(name);
+    store.remove = function(name, namespace) {
+      var key = getNamespacedKey(name, namespace);
       store.inMemoryCache[key] = null;
       storage.remove(key);
     };

--- a/test/unit/angularStorage/services/storeSpec.js
+++ b/test/unit/angularStorage/services/storeSpec.js
@@ -79,4 +79,26 @@ describe('angularStorage store', function() {
     expect(store.get('gonto')).not.to.equal(value);
   }));
 
+  it('should get objects correctly if a custom namespace is given', inject(function (store) {
+    var value = {
+      gonto: 'hola'
+    };
+    store.namespace = 'auth0';
+    store.set('gonto', value, 'customNamespace');
+    store.inMemoryCache = {};
+    expect(store.get('gonto', 'customNamespace')).to.eql(value);
+    expect(store.get('gonto', 'customNamespace')).not.to.equal(value);
+  }));
+
+  it('should get objects correctly if forced to not use a namespace', inject(function (store) {
+    var value = {
+      gonto: 'hola'
+    };
+    store.namespace = 'auth0';
+    store.set('noNamespace', value, null);
+    store.inMemoryCache = {};
+    expect(store.get('noNamespace', null)).to.eql(value);
+    expect(store.get('noNamespace', null)).not.to.equal(value);
+  }));
+
 });


### PR DESCRIPTION
I've implemented namespacing since I needed it for my current project, and because there was an issue for it already anyway (see #2). I've added a couple of tests that all pass. It supports the following functionality:
- Adding a namespace
- Adding an optional namespace delimiter (defaults to `.`)
- Specifying either a custom namespace or no namespace on a per-method basis (i.e. `get()`, `set()` and `remove()`). If the namespace is `null`, it will not use any namespace to get/set/remove that value (similar to the current implementation). If the namespace is given and not null, it will use that namespace to perform the operation. I'm not sure about the syntax yet, since I didn't want to change too much of the original API.

Also: you might notice that I have replaced all references to `this` with a top-level `store` object, this way we can reference it in the helper function that creates the namespaced key.

---
#### Namespacing configuration

I didn't want to create a whole new provider just to be able to configure things in Angular's `config()` block so I've declared the configuration on the service instead. There are two namespacing options you can set:
- `store.namespace` which defaults to `null` (current behaviour)
- `store.namespaceDelimiter` which defaults to `.` - this will result in stored keys such as `namespace.key`

---
#### Custom/no namespacing syntax

In the `store` methods, the namespace parameter can either be omitted (default behaviour), `null` where it will not use any namespace, or a value which will be used for the namespace instead of the default one. 
- `store.get(name, namespace)`
- `store.remove(name, namespace)`
- `store.set(name, elem, namespace)` -- This is the syntax I'm not sure about since the other two methods have the custom namespace right after the key name. I think this way is better though, since this behaviour most likely won't be used a lot, and if we moved it to the second argument, people would have to type `store.set('someName', null, 'someValue')` all the time. Would love to hear your feedback on this. 
