### PR TITLE
Add `main` to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-storage",
   "version": "0.0.9",
+  "main": "dist/angular-storage.js",
   "author": {
     "name": "Martin Gontovnikas",
     "email": "martin@gon.to"


### PR DESCRIPTION
This change allows the package to be required in `browserify` environments, whereas currently it will result in a `Cannot find module` error.