### PR TITLE
Added support for Browserify/Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./dist/angular-storage.js');
+module.exports = 'angular-storage';
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-storage",
   "version": "0.0.10",
-  "main": "dist/angular-storage.js",
+  "main": "index.js",
   "author": {
     "name": "Martin Gontovnikas",
     "email": "martin@gon.to"


### PR DESCRIPTION
Added `angular-storage` to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

angular.module('myApp', [require('angular-storage')]);

This is helpful for Browserify and Webpack.