### PR TITLE
Publish package to atmospherejs (for meteor use)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ bower install a0-angular-storage
 npm install angular-storage
 ````
 
+````bash
+meteor add auth0:angular-storage
+````
+
 ````html
 <script type="text/javascript" src="https://cdn.rawgit.com/auth0/angular-storage/master/dist/angular-storage.js"></script>
 ````

--- a/package.js
+++ b/package.js
@@ -1,0 +1,23 @@
+var packageName = 'auth0:angular-storage';
+var where = 'client';
+var version = '0.0.13';
+var summary = 'A storage library for AngularJS done right';
+var gitLink = 'https://github.com/auth0/angular-storage.git';
+var documentationFile = 'README.md';
+
+// Meta-data
+Package.describe({
+    name: packageName,
+    version: version,
+    summary: summary,
+    git: gitLink,
+    documentation: documentationFile
+});
+
+Package.onUse(function (api) {
+    api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+
+    api.use('angular:angular@1.3.3', where);
+
+    api.addFiles('dist/angular-storage.js', where);
+});


### PR DESCRIPTION
At the moment, meteor users can not add angular-storage to project using `meteor add` command.

This PR will fix it!

```bash
meteor add auth0:angular-storage
```

--
I set package name with _auth0_ prefix, so if you want to publish it in that form **you have to create  Meteor developer account**.

[See instructions](https://atmospherejs.com/i/publishing)